### PR TITLE
fix: set to working state

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ import torch
 import torchvision
 from matplotlib import pyplot as plt
 from tsimcne.tsimcne import TSimCNE
+from torchvision import transforms
 
 # get the cifar dataset (make sure to adapt `data_root` to point to your folder)
 data_root = "experiments/cifar/out/cifar10"
@@ -54,19 +55,24 @@ dataset_train = torchvision.datasets.CIFAR10(
     root=data_root,
     download=True,
     train=True,
+    transform=transforms.ToTensor()  # Convert PIL images to tensors
 )
 dataset_test = torchvision.datasets.CIFAR10(
     root=data_root,
     download=True,
     train=False,
+    transform=transforms.ToTensor()  # Convert PIL images to tensors
 )
 dataset_full = torch.utils.data.ConcatDataset([dataset_train, dataset_test])
 
-# create the object (here we run t-SimCNE with fewer epochs
-# than in the paper; there we used [1000, 50, 450]).
-tsimcne = TSimCNE(total_epochs=[500, 50, 250])
+# create the object with explicit image size and data transform
+tsimcne = TSimCNE(
+    total_epochs=[500, 50, 250],
+    image_size=(32, 32),  # CIFAR10 images are 32x32
+    data_transform="is_included"  # Tell TSimCNE that the data is already transformed
+)
 
-# train on the augmented/contrastive dataloader (this takes the most time)
+# train on the augmented/contrastive dataloader
 tsimcne.fit(dataset_full)
 
 # map the original images to 2D

--- a/tsimcne/tsimcne.py
+++ b/tsimcne/tsimcne.py
@@ -215,7 +215,7 @@ class PLtSimCNE(lightning.LightningModule, HyperparametersMixin):
 
             case "parameter":
                 self.dof_ = torch.nn.Parameter(
-                    torch.tensor(1.0, dtype=torch.float64)
+                    torch.tensor(1.0, dtype=torch.float32)
                 )
                 self.dofs = [self.dof_] * self.n_epochs
 
@@ -706,6 +706,7 @@ class TSimCNE:
         trainer_kwargs=None,
         num_workers=8,
         dl_kwargs=None,
+        use_ffcv=False,
         float32_matmul_precision="medium",
     ):
         self.model = model
@@ -729,6 +730,7 @@ class TSimCNE:
         self.num_workers = num_workers
         self.dl_kwargs = dict() if dl_kwargs is None else dl_kwargs
         self.float32_matmul_precision = float32_matmul_precision
+        self.use_ffcv = use_ffcv
 
         self._handle_parameters()
 
@@ -864,7 +866,7 @@ class TSimCNE:
                 optimizer_name=self.optimizer,
                 lr_scheduler_name=self.lr_scheduler,
                 lr=lr,
-                warmup=warmup_epochs,
+                warmup_epochs=warmup_epochs,
                 out_dim=self.out_dim,
             )
             if n_stage == 0:


### PR DESCRIPTION
Hi, thanks for the library.

I was trying to experiment with it yesterday and noticed that neither the `pip` or manual installation were working. I identified two problems:

1. undefined `use_ffcv` in the construction;
2. `PLtSimCNE` expects `warmup_epochs` not `warmup`.

Also, `torch.float64` is causing problems with Metal backend. Is that necessary?

This PR sets the library to a working state:

<img width="468" alt="Screenshot 2025-05-02 at 08 56 21" src="https://github.com/user-attachments/assets/ae43dd43-3cc5-4706-b67e-4e64d37f1aa2" />
